### PR TITLE
RDPP-489: avoid pushing undefined models.

### DIFF
--- a/lib/utility/execComposite.js
+++ b/lib/utility/execComposite.js
@@ -103,7 +103,9 @@ exports.execComposite = function execComposite(params) {
 				cb(err);
 			}
 			else {
-				instances[model.name] = instance;
+				if (instance) {
+					instances[model.name] = instance;
+				}
 				cb();
 			}
 		});

--- a/test/search.js
+++ b/test/search.js
@@ -67,6 +67,31 @@ describe('Find / Query', function () {
 			});
 		});
 
+		it('should return no results when query with invalid where', function (callback) {
+
+			var obj = {
+				title: 'Test Title',
+				content: 'Test Content',
+				author_id: IDs.user,
+				attachment_id: IDs.attachment
+			};
+			Models.article.create(obj, function (err, instance) {
+				should(err).be.not.ok;
+				should(instance).be.an.Object;
+				var options = {
+					where: 'bad',
+					sel: { content: 1, author_first_name: 1 },
+					order: { title: -1, content: 1 },
+					limit: 3,
+					skip: 0
+				};
+				Models.article.query(options, function (err, coll) {
+					should(err).be.not.ok;
+					should(coll).have.length(0);
+					callback();
+				});
+			});
+		});
 	});
 
 	it('should be able to find all instances', function (next) {


### PR DESCRIPTION
I'm pretty sure this is also an alternate fix for ARRCONN-51. Personally I prefer not getting into a state where the instances contains invalid data but realistically either fix should work. I'm really only creating this PR to get some feedback on the preferred process for future appc.composite changes.